### PR TITLE
Add root path link to logo title

### DIFF
--- a/src/views/dashboard/components/core/Drawer.vue
+++ b/src/views/dashboard/components/core/Drawer.vue
@@ -24,8 +24,9 @@
     <v-list
       dense
       nav
+      flat
     >
-      <v-list-item>
+      <v-list-item href="/">
         <v-list-item-avatar
           class="align-self-center"
           color="white"


### PR DESCRIPTION
### 修正内容
- ルートパスをリンクとして追加

### 起きていた事象
- ロゴやタイトル箇所にリンクがついてなかった

### スクリーンショット
[![Image from Gyazo](https://i.gyazo.com/4fe4f347f2867ef6309edbb32797e4a9.gif)](https://gyazo.com/4fe4f347f2867ef6309edbb32797e4a9)
