### PR TITLE
fix: sort-modal

### DIFF
--- a/src/views/dashboard/tables/TablePane.vue
+++ b/src/views/dashboard/tables/TablePane.vue
@@ -6,7 +6,6 @@
       :headers="headers"
       :items="areas"
       :items-per-page="itemsPerPage"
-      item-key="code"
       class="elevation-1"
       multi-sort
       locale="ja-jp"
@@ -35,7 +34,6 @@
 
 <script>
   // Ajax通信ライブラリ
-  import axios from 'axios'
   import DATA from '../../../../public/data/data.json'
 
   export default {
@@ -53,21 +51,6 @@
         { text: 'GitHub', sortable: true, value: 'source' },
       ],
     }),
-    mounted: function () {
-      // テーブルオブジェクト生成
-      // this.tableCreate()
-    },
-    methods: {
-      // テーブルオブジェクト生成
-      tableCreate: function () {
-        axios.get('/data/data.json').then(function (response) {
-          this.area = response.data
-          // console.log(this.area)
-        }.bind(this)).catch(function (e) {
-          // console.error(e)
-        })
-      },
-    },
   }
 </script>
 

--- a/src/views/dashboard/tables/TablePaneShort.vue
+++ b/src/views/dashboard/tables/TablePaneShort.vue
@@ -7,7 +7,6 @@
       :items="areas"
       :items-per-page="itemsPerPage"
       :page.sync="page"
-      item-key="prefecture"
       class="elevation-1"
       locale="ja-jp"
       loading-text="読込中"
@@ -38,8 +37,6 @@
 </template>
 
 <script>
-  // Ajax通信ライブラリ
-  import axios from 'axios'
   import DATA from '../../../../public/data/data.json'
 
   export default {
@@ -56,21 +53,6 @@
         { text: 'URL', sortable: true, value: 'url' },
       ],
     }),
-    mounted: function () {
-      // テーブルオブジェクト生成
-      // this.tableCreate()
-    },
-    methods: {
-      // テーブルオブジェクト生成
-      tableCreate: function () {
-        axios.get('/data/data.json').then(function (response) {
-          this.area = response.data
-          // console.log(this.area)
-        }.bind(this)).catch(function (e) {
-          // console.error(e)
-        })
-      },
-    },
   }
 </script>
 


### PR DESCRIPTION
close #12 
`[Vue warn]: Duplicate keys detected: '40'. This may cause an update error.`
DataTableの箇所でエラーが起きていたので固有のキーがあたるようにした
デフォルトのkey-idは`"id"`でそれぞれのareaのidが入る

* 関連してaxios経由でデータを参照する処理は使っていなかったので削除した

[![Image from Gyazo](https://i.gyazo.com/8434016f9db551e6ed16475f41921a0e.gif)](https://gyazo.com/8434016f9db551e6ed16475f41921a0e)
