### PR TITLE
浜松市の公式COVID-19サイトを追加

### DIFF
--- a/public/data/data.json
+++ b/public/data/data.json
@@ -486,10 +486,10 @@
         "country": "日本",
         "date": "",
         "forkedSites": "記載済",
-        "opendata": "",
+        "opendata": "https://opendata.pref.shizuoka.jp/dataset/8138.html",
         "prefecture": "静岡県",
         "relation": "浜松市公式",
-        "source": "",
+        "source": "https://github.com/code-for-hamamatsu/covid19",
         "status": "リリース",
         "team": "有志（Code for Hamamatsu）",
         "url": "https://stopcovid19.code4hamamatsu.org/"

--- a/public/data/data.json
+++ b/public/data/data.json
@@ -480,6 +480,21 @@
         "url": "https://stopcovid19-shizuoka-dev.netlify.com/"
     },
     {
+        "city": "浜松市",
+        "code": 22,
+        "contact": "",
+        "country": "日本",
+        "date": "",
+        "forkedSites": "記載済",
+        "opendata": "",
+        "prefecture": "静岡県",
+        "relation": "浜松市公式",
+        "source": "",
+        "status": "リリース",
+        "team": "有志（Code for Hamamatsu）",
+        "url": "https://stopcovid19.code4hamamatsu.org/"
+    },
+    {
         "city": "",
         "code": 23,
         "contact": "info@code4.nagoya",


### PR DESCRIPTION
静岡県浜松市ではITコミュニティ有志により4/1から公開を始めました。
こちらのサイトのリストに加えていただきたくPRをいたしました。

公開URL: https://stopcovid19.code4hamamatsu.org/
リポジトリ: https://github.com/code-for-hamamatsu/covid19
